### PR TITLE
Allow this.props.value

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -36,7 +36,7 @@ class IntlCurrencyInput extends Component {
   }
 
   componentDidMount() {
-    const value = this.props.defaultValue || 0
+    const value =  this.props.value || this.props.defaultValue || this.props.defaultValue || 0
     this.setMaskedValue(value)
   }
 


### PR DESCRIPTION
accept this.props.value is important because it allows for compatibility with other forms libs